### PR TITLE
Update provider.js

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,24 +1,14 @@
-'use strict';
-
-const path = require('path');
-const slugify = require('slugify');
-const { Storage } = require('@google-cloud/storage');
-const { pipeline } = require('stream/promises');
+import path from 'path';
+import slugify from 'slugify';
+import { Storage } from '@google-cloud/storage';
+import { pipeline } from 'stream/promises';
 
 /**
- * lodash _.get native port
- *
- * checkout: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_get
- *
- * Another solution is use destructor variable with default value as {} on each layer
- * but it appears so tricky.
- *
- * const { a: { b: { c: d = 42 } = {} } = {} } = object
+ * A native implementation of _.get.
  */
-const get = (obj, path, defaultValue = undefined) => {
+const get = (obj, pathStr, defaultValue = undefined) => {
   const travel = (regexp) =>
-    String.prototype.split
-      .call(path, regexp)
+    String.prototype.split.call(pathStr, regexp)
       .filter(Boolean)
       .reduce((res, key) => (res !== null && res !== undefined ? res[key] : res), obj);
   const result = travel(/[,[\]]+?/) || travel(/[,[\].]+?/);
@@ -27,11 +17,6 @@ const get = (obj, path, defaultValue = undefined) => {
 
 /**
  * Sets a configuration field value.
- *
- * @param {*} fieldValue - The value to validate.
- * @param {*} defaultValue - The default value to return if the field is not provided or is invalid.
- * @returns {*} The validated field value or the default value.
- * @throws {Error} If the default value is undefined or the field value is undefined.
  */
 const setConfigField = (fieldValue, defaultValue) => {
   if (typeof defaultValue === 'undefined') throw new Error('Default value is required!');
@@ -48,115 +33,85 @@ const setConfigField = (fieldValue, defaultValue) => {
 };
 
 /**
- * Check validity of Service Account configuration
- * @param config
- * @returns {{private_key}|{client_email}|{project_id}|any}
+ * Check validity of Service Account configuration.
  */
 const checkServiceAccount = (config = {}) => {
   if (!config.bucketName) {
     throw new Error('"Bucket name" is required!');
   }
   if (!config.baseUrl) {
-    /** Set to default **/
     config.baseUrl = 'https://storage.googleapis.com/{bucket-name}';
   }
   if (!config.basePath) {
     config.basePath = '';
   }
-
-  /** Check or set default boolean optional variable */
-  config.publicFiles = setConfigField(config.publicFiles, true); // default value
-  config.uniform = setConfigField(config.uniform, false); // default value
-  config.skipCheckBucket = setConfigField(config.skipCheckBucket, false); // default value
+  config.publicFiles = setConfigField(config.publicFiles, true);
+  config.uniform = setConfigField(config.uniform, false);
+  config.skipCheckBucket = setConfigField(config.skipCheckBucket, false);
 
   let serviceAccount;
   if (config.serviceAccount) {
     try {
-      serviceAccount =
-        typeof config.serviceAccount === 'string'
-          ? JSON.parse(config.serviceAccount)
-          : config.serviceAccount;
+      serviceAccount = typeof config.serviceAccount === 'string'
+        ? JSON.parse(config.serviceAccount)
+        : config.serviceAccount;
+      // Replace escaped newline characters in private_key
+      if (serviceAccount.private_key) {
+        serviceAccount.private_key = serviceAccount.private_key.replace(/\\n/g, '\n');
+      }
     } catch (e) {
       throw new Error(
-        'Error parsing data "Service Account JSON", please be sure to copy/paste the full JSON file.'
+        'Error parsing "Service Account JSON". Please ensure you copy the full JSON file.'
       );
     }
-
-    /**
-     * Check exist
-     */
     if (!serviceAccount.project_id) {
-      throw new Error(
-        'Error parsing data "Service Account JSON". Missing "project_id" field in JSON file.'
-      );
+      throw new Error('Missing "project_id" field in Service Account JSON.');
     }
     if (!serviceAccount.client_email) {
-      throw new Error(
-        'Error parsing data "Service Account JSON". Missing "client_email" field in JSON file.'
-      );
+      throw new Error('Missing "client_email" field in Service Account JSON.');
     }
     if (!serviceAccount.private_key) {
-      throw new Error(
-        'Error parsing data "Service Account JSON". Missing "private_key" field in JSON file.'
-      );
+      throw new Error('Missing "private_key" field in Service Account JSON.');
     }
   }
-
   return serviceAccount;
 };
 
 /**
- * Check bucket exist, or create it
- * @param GCS
- * @param bucketName
- * @returns {Promise<void>}
+ * Check if bucket exists.
  */
 const checkBucket = async (GCS, bucketName) => {
-  let bucket = GCS.bucket(bucketName);
+  const bucket = GCS.bucket(bucketName);
   const [exists] = await bucket.exists();
   if (!exists) {
-    throw new Error(
-      `An error occurs when we try to retrieve the Bucket "${bucketName}". Check if bucket exist on Google Cloud Platform.`
-    );
+    throw new Error(`Bucket "${bucketName}" does not exist on Google Cloud Storage.`);
   }
 };
 
 /**
- * Merge uploadProvider config with gcs key in custom Strapi config
- * @param providerConfig
- * @returns {{private_key}|{client_email}|{project_id}|any}
+ * Merge provider config with any additional custom configurations.
+ * (Updated to remove the dependency on a global "strapi" variable.)
  */
 const mergeConfigs = (providerConfig) => {
-  const customGcsConfig = get(strapi, 'config.gcs', {});
-  const customEnvGcsConfig = get(strapi, 'config.currentEnvironment.gcs', {});
-  return { ...providerConfig, ...customGcsConfig, ...customEnvGcsConfig };
+  // For the latest Strapi versions, assume providerConfig is complete.
+  return providerConfig;
 };
 
 /**
- * Generate upload filename including path
- *
- * @param basePath
- * @param file
- * @returns string
+ * Generate an upload file name including path.
  */
 const generateUploadFileName = (basePath, file) => {
-  const backupPath =
-    file.related && file.related.length > 0 && file.related[0].ref
-      ? `${file.related[0].ref}`
-      : `${file.hash}`;
+  const backupPath = file.related && file.related.length > 0 && file.related[0].ref
+    ? `${file.related[0].ref}`
+    : `${file.hash}`;
   const filePath = file.path ? `${file.path}/` : `${backupPath}/`;
   const extension = file.ext.toLowerCase();
-  const fileName = slugify(path.basename(file.hash));
+  const fileName = slugify(path.basename(file.hash), { lower: true, strict: true });
   return `${basePath}${filePath}${fileName}${extension}`;
 };
 
 /**
- * Prepare file before upload
- * @param file
- * @param config
- * @param basePath
- * @param GCS
- * @returns {Promise<{fileAttributes: {metadata: (*|{contentDisposition: string, cacheControl: string}), gzip: (string|boolean|((buf: InputType, callback: CompressCallback) => void)|((buf: InputType, options: ZlibOptions, callback: CompressCallback) => void)|gzip|*), contentType: (string|string|*)}, fullFileName: (string|Promise<string>|*|string)}>}
+ * Prepare file before upload.
  */
 const prepareUploadFile = async (file, config, basePath, GCS) => {
   let deleteFile = false;
@@ -175,35 +130,30 @@ const prepareUploadFile = async (file, config, basePath, GCS) => {
   }
   const asciiFileName = file.name.normalize('NFKD').replace(/[\u0300-\u036f]/g, '');
   const fileAttributes = {
-    contentType:
-      typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,
+    contentType: typeof config.getContentType === 'function' ? config.getContentType(file) : file.mime,
     gzip: typeof config.gzip === 'boolean' ? config.gzip : 'auto',
-    metadata:
-      typeof config.metadata === 'function'
-        ? config.metadata(file)
-        : {
-            contentDisposition: `inline; filename="${asciiFileName}"`,
-            cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
-          },
+    metadata: typeof config.metadata === 'function'
+      ? config.metadata(file)
+      : {
+          contentDisposition: `inline; filename="${asciiFileName}"`,
+          cacheControl: `public, max-age=${config.cacheMaxAge || 3600}`,
+        },
   };
   if (!config.uniform) {
     fileAttributes.public = config.publicFiles;
   }
-
   return { fileAttributes, bucketFile, fullFileName, deleteFile };
 };
 
 /**
- *
- * @param providerConfig
- * @returns {{uploadStream(*): Promise<void>, upload(*): Promise<void>, delete(*): Promise<void>}}
+ * Initialize the Google Cloud Storage provider.
  */
 const init = (providerConfig) => {
   const config = mergeConfigs(providerConfig);
   const serviceAccount = checkServiceAccount(config);
   let GCS;
   if (serviceAccount) {
-    // Provide service account credentials
+    // Provide service account credentials.
     GCS = new Storage({
       projectId: serviceAccount.project_id,
       credentials: {
@@ -212,10 +162,9 @@ const init = (providerConfig) => {
       },
     });
   } else {
-    // Storage will attempt to find Application Default Credentials
+    // Fall back to Application Default Credentials.
     GCS = new Storage();
   }
-
   const basePath = `${config.basePath}/`.replace(/^\/+/, '');
   const baseUrl = config.baseUrl.replace('{bucket-name}', config.bucketName);
 
@@ -229,17 +178,14 @@ const init = (providerConfig) => {
           GCS
         );
         if (deleteFile) {
-          console.info('File already exists. Try to remove it.');
+          console.info('File already exists. Removing it.');
           await this.delete(file);
         }
-
         await bucketFile.save(file.buffer, fileAttributes);
         file.url = `${baseUrl}/${fullFileName}`;
         console.debug(`File successfully uploaded to ${file.url}`);
       } catch (error) {
-        // Re-throw so that the upload operation will fail
-        // and error will surface to the user in the Strapi admin front-end
-        console.error(`Error uploading file to Google Cloud Storage: ${error.message}`);
+        console.error(`Error uploading file: ${error.message}`);
         throw error;
       }
     },
@@ -252,25 +198,22 @@ const init = (providerConfig) => {
           GCS
         );
         if (deleteFile) {
-          console.info('File already exists. Try to remove it.');
+          console.info('File already exists. Removing it.');
           await this.delete(file);
         }
         await pipeline(file.stream, bucketFile.createWriteStream(fileAttributes));
-        console.debug(`File successfully uploaded to ${file.url}`);
         file.url = `${baseUrl}/${fullFileName}`;
+        console.debug(`File successfully uploaded to ${file.url}`);
       } catch (error) {
-        // Re-throw so that the upload operation will fail
-        // and error will surface to the user in the Strapi admin front-end
-        console.error(`Error uploading file to Google Cloud Storage: ${error.message}`);
+        console.error(`Error uploading stream: ${error.message}`);
         throw error;
       }
     },
     async delete(file) {
       if (!file.url) {
-        console.warn('Remote file was not found, you may have to delete manually.');
+        console.warn('No remote file URL found; manual deletion may be required.');
         return;
       }
-
       const fileName = file.url.replace(`${baseUrl}/`, '');
       const bucket = GCS.bucket(config.bucketName);
       try {
@@ -278,10 +221,8 @@ const init = (providerConfig) => {
         console.debug(`File ${fileName} successfully deleted`);
       } catch (error) {
         if (error.code === 404) {
-          console.warn('Remote file was not found, you may have to delete manually.');
+          console.warn('File not found on remote storage; manual deletion may be needed.');
         }
-        // based on last code, it will never throw (resolves and rejects)
-        // throw error;
       }
     },
     isPrivate() {
@@ -300,10 +241,10 @@ const init = (providerConfig) => {
   };
 };
 
-module.exports = {
+export {
   get,
-  checkServiceAccount,
   setConfigField,
+  checkServiceAccount,
   checkBucket,
   mergeConfigs,
   generateUploadFileName,


### PR DESCRIPTION
feat(provider): update Provider.js for Strapi v5 & latest Node.js compatibility

- Convert to ES module syntax (import/export) for modern Node.js usage.
- Remove dependency on global "strapi" during configuration merge.
- Enhance service account parsing by replacing escaped newline characters in private_key.
- Improve slugify usage with lowercasing and strict options.
- Refactor logging and update ordering in uploadStream method.

This commit ensures the provider works seamlessly with the latest Strapi version, Node.js, and npm.